### PR TITLE
Replace Var with let

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 console.log("JS loaded!");
 
 document.addEventListener('DOMContentLoaded', function() {
-    var elems = document.querySelectorAll('.sidenav');
-    var instances = M.Sidenav.init(elems, options);
+    let elems = document.querySelectorAll('.sidenav');
+    let instances = M.Sidenav.init(elems, options);
   });
        


### PR DESCRIPTION
Declaring global variables using var can cause future problems and can easily be manipulated from the outside causing several open vulnerabilities while scaling.